### PR TITLE
Fix city title for detail page

### DIFF
--- a/_layouts/city.html
+++ b/_layouts/city.html
@@ -9,10 +9,10 @@ layout: default
     <div id="map"></div>
   </div>
   <div class="col-lg-6 col-md-6">
-    <h2>Open Data Day {{ page.name }}</h2>
+    <h2>Open Data Day {{ page.eventTitle }}</h2>
     <ul class="city-list">
       <li class="box">
-        <div class="box-header">Open Data Day {{ page.name }}</div>
+        <div class="box-header">Open Data Day {{ page.eventTitle }}</div>
         <div class="box-content">
           {{ page.where }}<br/>
           {{ page.when }}


### PR DESCRIPTION
page.name ist ein reserviertes wort. 
war das schon immer so?
auf jeden fall ist page.name der filename und nicht das was im frontmatter steht.
